### PR TITLE
Dodanie virtualenv do .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+virtualenv


### PR DESCRIPTION
Wirtualne środowiska Pythona nie powinny być synchronizowane przez Gita.