### PR TITLE
W gulpfile.js zdefiniowano akcję css:compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 		![Sprawdzanie wersji Django](http://i.imgur.com/yDD5C37.png)
     6. Teraz instalujemy [Gulp](http://gulpjs.com/ "Strana Gulp'a")'a i potrzebne do jego działania moduły.</br>
   	Będąc w głównym folderze projektu wpisujemy w konsolę: `npm install`. NodePackageManager automatycznie zainstaluje za nas potrzebne moduły które są zawarde w pliku `package.json`.
-    7. Po instalacji modułów `npm` w konsolę wpisujemy komendę: `gulp compile_css`.</br>
+    7. Po instalacji modułów `npm` w konsolę wpisujemy komendę: `gulp css:compile`.</br>
   	Powinniśmy ujrzeć taki widok:</br>      
         ![Kompilowanie plików scss](http://i.imgur.com/dRAfQxz.png)
 4. Uruchomienie serwera i dodawanie danych:</br>


### PR DESCRIPTION
W pliku gulpfile akcja nazywa się css:compile, a nie compile_css – dla tej wyrzuca błąd: "Task 'compile_css' is not in your gulpfile"